### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         framework: [net48, net8.0-windows]


### PR DESCRIPTION
Potential fix for [https://github.com/fengyec2/FreeMove/security/code-scanning/1](https://github.com/fengyec2/FreeMove/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job so its token scope is constrained.  
Best fix without changing functionality: in `.github/workflows/build-release.yml`, under `jobs.build` (after `build:` and before `strategy:`), add:

```yml
permissions:
  contents: read
```

This preserves current behavior (checkout/build/upload artifacts) while documenting and enforcing least privilege. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
